### PR TITLE
GET lists of groups

### DIFF
--- a/rbac/get_user_group.md
+++ b/rbac/get_user_group.md
@@ -1,0 +1,9 @@
+# Run from console server
+CERT=$(/usr/local/bin/puppet config print hostcert)
+CACERT=$(/usr/local/bin/puppet config print localcacert)
+PRVKEY=$(/usr/local/bin/puppet config print hostprivkey)
+OPTIONS="--cert ${CERT} --cacert ${CACERT} --key ${PRVKEY}"
+HOST=$(puppet agent --configprint certname)
+
+# GET user groups
+curl -s -X GET $OPTIONS https://$HOST:4433/rbac-api/v1/groups | python -m json.tool


### PR DESCRIPTION
[Fetches all user groups](https://docs.puppet.com/pe/latest/rbac_usergroups_v1.html#get-groups) from puppet console.  This is helpful when user groups need to be deleted from the console, which can only be performed via the API.
