### PR TITLE
Fix the certificate cleaning script

### DIFF
--- a/puppet/clean_certificate.sh
+++ b/puppet/clean_certificate.sh
@@ -1,12 +1,41 @@
 #!/bin/bash
+#
+# To emulate a `puppet cert clean <NODE>` using the API, we do 2 operations:
+#   1. PUT (SAVE) with a desired_state of 'revoked'
+#   2. DELETE
+#
+# https://docs.puppet.com/puppet/4.5/reference/http_api/http_certificate_status.html
+#
+# To authenticate with a certficate other than pe-internal-dashboard, you must
+# add that certificate name to auth.conf's certificate_status rule on the CA.
+#
 
-CA='puppetca.puppetdebug.vlan'
-NODE='mynode.puppetdebug.vlan'
+CA="$(hostname -f)"
+NODE='test_node.puppet.vm'
+
+curl -X PUT \
+  -H       "Content-Type: text/pson" \
+  --data   '{"desired_state":"revoked"}' \
+  --silent \
+  --tlsv1  \
+  --cert   /etc/puppetlabs/puppet/ssl/certs/pe-internal-dashboard.pem \
+  --key    /etc/puppetlabs/puppet/ssl/private_keys/pe-internal-dashboard.pem \
+  --cacert /etc/puppetlabs/puppet/ssl/certs/ca.pem \
+  https://${CA}:8140/puppet-ca/v1/certificate_status/${NODE}?environment=production | python -m json.tool
 
 curl -X DELETE \
-  -H "Content-Type: text/pson" \
-  --tlsv1 \
-  --cert   $(puppet config print hostcert) \
-  --key    $(puppet config print hostprivkey) \
-  --cacert $(puppet config print localcacert) \
+  --tlsv1  \
+  --silent \
+  --cert   /etc/puppetlabs/puppet/ssl/certs/pe-internal-dashboard.pem \
+  --key    /etc/puppetlabs/puppet/ssl/private_keys/pe-internal-dashboard.pem \
+  --cacert /etc/puppetlabs/puppet/ssl/certs/ca.pem \
   https://${CA}:8140/puppet-ca/v1/certificate_status/${NODE}?environment=production | python -m json.tool
+
+# View cert status. After cleaninig, it should be "not found".
+#curl -X GET \
+#  --tlsv1  \
+#  --cert   /etc/puppetlabs/puppet/ssl/certs/pe-internal-dashboard.pem \
+#  --key    /etc/puppetlabs/puppet/ssl/private_keys/pe-internal-dashboard.pem \
+#  --cacert /etc/puppetlabs/puppet/ssl/certs/ca.pem \
+#  https://${CA}:8140/puppet-ca/v1/certificate_status/${NODE}?environment=production
+


### PR DESCRIPTION
This commit fixes a few things with the cert clean script:
- A "clean" should be a revocation and a deletion.
- By default, only pe-internal-dashboard is allowed to do this.
- Added a commented out curl that shows the cert status.
