### PR TITLE
automatically determine API endpoint host

### DIFF
--- a/classifier/check_last_refresh.sh
+++ b/classifier/check_last_refresh.sh
@@ -9,7 +9,8 @@ CERT="$(puppet master   --confdir "${CONFDIR}" --configprint hostcert)"
 CACERT="$(puppet master --confdir "${CONFDIR}" --configprint localcacert)"
 PRVKEY="$(puppet master --confdir "${CONFDIR}" --configprint hostprivkey)"
 OPTIONS="--cert ${CERT} --cacert ${CACERT} --key ${PRVKEY}"
-CONSOLE="$(awk '/server: /{print $NF}' "${CONFDIR}/classifier.yaml")"
+SET_SERVER=CONSOLE="$(awk '/server: /{print $NF}' "${CONFDIR}/classifier.yaml")"
+CONSOLE="${CONSOLE:-$SET_SERVER}"
 
 /opt/puppetlabs/puppet/bin/curl -s -X GET $OPTIONS "https://${CONSOLE}:4433/classifier-api/v1/last-class-update" | python -m json.tool
 

--- a/classifier/get_all_services_status.sh
+++ b/classifier/get_all_services_status.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-CONSOLE=$(puppet config print server)
+SET_SERVER=$(puppet config print server)
+CONSOLE="${CONSOLE:-$SET_SERVER}"
 
 curl -X GET \
   --tlsv1 \

--- a/classifier/get_all_services_status.sh
+++ b/classifier/get_all_services_status.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-CONSOLE='master.puppetlabs.vm'
+CONSOLE=$(puppet config print server)
+
 curl -X GET \
   --tlsv1 \
   --cert   $(puppet config print hostcert) \

--- a/classifier/get_console_groups.sh
+++ b/classifier/get_console_groups.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-CONSOLE='pe-385-master.puppetdebug.vlan'
+
+CONSOLE=$(puppet config print server)
 
 curl -k -X GET https://${CONSOLE}:4433/classifier-api/v1/groups \
   --cert $(puppet config print hostcert) \

--- a/classifier/get_console_groups.sh
+++ b/classifier/get_console_groups.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-CONSOLE=$(puppet config print server)
+SET_SERVER=$(puppet config print server)
+CONSOLE="${CONSOLE:-$SET_SERVER}"
 
 curl -k -X GET https://${CONSOLE}:4433/classifier-api/v1/groups \
   --cert $(puppet config print hostcert) \

--- a/classifier/get_node_group.sh
+++ b/classifier/get_node_group.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-CONSOLE=$(puppet config print server)
+SET_SERVER=$(puppet config print server)
+CONSOLE="${CONSOLE:-$SET_SERVER}"
 NODE_GROUP=$1
 RUBY=/opt/puppetlabs/puppet/bin/ruby
 

--- a/classifier/get_node_group_id.sh
+++ b/classifier/get_node_group_id.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-CONSOLE=$(puppet config print server)
+SET_SERVER=$(puppet config print server)
+CONSOLE="${CONSOLE:-$SET_SERVER}"
 NODE_GROUP=$1
 RUBY=/opt/puppetlabs/puppet/bin/ruby
 

--- a/classifier/get_node_group_parent_id.sh
+++ b/classifier/get_node_group_parent_id.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-CONSOLE=$(puppet config print server)
+SET_SERVER=$(puppet config print server)
+CONSOLE="${CONSOLE:-$SET_SERVER}"
 NODE_GROUP=$1
 RUBY=/opt/puppetlabs/puppet/bin/ruby
 

--- a/classifier/get_node_record.sh
+++ b/classifier/get_node_record.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-CONSOLE='pe-385-master.puppetdebug.vlan'
+
+CONSOLE=$(puppet config print server)
 NODE='yournode.puppetdebug.vlan'
 
 curl -k -X GET https://${CONSOLE}:4433/classifier-api/v1/nodes/${NODE} \

--- a/classifier/get_node_record.sh
+++ b/classifier/get_node_record.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-CONSOLE=$(puppet config print server)
+SET_SERVER=$(puppet config print server)
+CONSOLE="${CONSOLE:-$SET_SERVER}"
 NODE='yournode.puppetdebug.vlan'
 
 curl -k -X GET https://${CONSOLE}:4433/classifier-api/v1/nodes/${NODE} \

--- a/classifier/restore_nc_groups.sh
+++ b/classifier/restore_nc_groups.sh
@@ -2,7 +2,7 @@
 
 # Variables for the console node and the classifier dump file
 NC_BACKUP='node_classifier_dump.json'
-CONSOLE='pe-385-master.puppetdebug.vlan'
+CONSOLE=$(puppet config print server)
 
 # Exit if the node classifier backup file isn't found
 [[ -f $NC_BACKUP ]] || { echo "Unable to find NC backup: ${NC_BACKUP}" >&2; exit 1; }

--- a/classifier/restore_nc_groups.sh
+++ b/classifier/restore_nc_groups.sh
@@ -2,7 +2,8 @@
 
 # Variables for the console node and the classifier dump file
 NC_BACKUP='node_classifier_dump.json'
-CONSOLE=$(puppet config print server)
+SET_SERVER=$(puppet config print server)
+CONSOLE="${CONSOLE:-$SET_SERVER}"
 
 # Exit if the node classifier backup file isn't found
 [[ -f $NC_BACKUP ]] || { echo "Unable to find NC backup: ${NC_BACKUP}" >&2; exit 1; }

--- a/classifier/search_for_a_class.sh
+++ b/classifier/search_for_a_class.sh
@@ -2,6 +2,9 @@
 # This script searches the puppetserver API for all known classes that match ^pe_.*
 # Adjust the search pattern to tailor this script to your particular search pattern.
 
+SET_SERVER=$(puppet config print server)
+CONSOLE="${CONSOLE:-$SET_SERVER}"
+
 # Set variables for the curl.
 CERT="/etc/puppetlabs/puppet/ssl/certs/pe-internal-classifier.pem"
 KEY="/etc/puppetlabs/puppet/ssl/private_keys/pe-internal-classifier.pem"
@@ -12,5 +15,5 @@ CACERT="/etc/puppetlabs/puppet/ssl/certs/ca.pem"
                                 --cert   "$CERT" \
                                 --key    "$KEY" \
                                 --cacert "$CACERT" \
-                                "https://$(hostname -f):8140/puppet/v3/resource_types/^pe_.*?environment=production&kind=class" | python -m json.tool | grep \"name\"
+                                "https://${CONSOLE}:8140/puppet/v3/resource_types/^pe_.*?environment=production&kind=class" | python -m json.tool | grep \"name\"
 

--- a/codemanager/deploy_environment.sh
+++ b/codemanager/deploy_environment.sh
@@ -2,6 +2,7 @@
 # Show credentials with:  `puppet access show`
 # puppet access login --service-url https://<HOSTNAME OF PUPPET ENTERPRISE CONSOLE>:4433/rbac-api --lifetime 180d
 
+CODE_MANAGER=$(puppet config print server)
 
 curl -k -X POST -H 'Content-Type: application/json' \
   -H "X-Authentication: `cat ~/.puppetlabs/token`" \

--- a/codemanager/deploy_environment.sh
+++ b/codemanager/deploy_environment.sh
@@ -2,7 +2,8 @@
 # Show credentials with:  `puppet access show`
 # puppet access login --service-url https://<HOSTNAME OF PUPPET ENTERPRISE CONSOLE>:4433/rbac-api --lifetime 180d
 
-CODE_MANAGER=$(puppet config print server)
+SET_SERVER=$(puppet config print server)
+CODE_MANAGER="${CODE_MANAGER:-$SET_SERVER}"
 
 curl -k -X POST -H 'Content-Type: application/json' \
   -H "X-Authentication: `cat ~/.puppetlabs/token`" \

--- a/puppet/clean_certificate.sh
+++ b/puppet/clean_certificate.sh
@@ -10,7 +10,8 @@
 # add that certificate name to auth.conf's certificate_status rule on the CA.
 #
 
-CA=$(puppet config print ca_name | sed 's/^.*\s//')
+SET_SERVER=$(puppet config print ca_name | sed 's/^.*\s//')
+CA="${CA:-$SET_SERVER}"
 NODE='test_node.puppet.vm'
 
 curl -X PUT \

--- a/puppet/clean_certificate.sh
+++ b/puppet/clean_certificate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CA='puppetca.puppetdebug.vlan'
+CA=$(puppet config print ca_name | sed 's/^.*\s//')
 NODE='mynode.puppetdebug.vlan'
 
 curl -X DELETE \

--- a/puppet/sign_certificate.sh
+++ b/puppet/sign_certificate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CA='puppetca.puppetdebug.vlan'
+CA=$(puppet config print ca_name | sed 's/^.*\s//')
 NODE='mynode.puppetdebug.vlan'
 
 curl -X PUT \

--- a/puppet/sign_certificate.sh
+++ b/puppet/sign_certificate.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-CA=$(puppet config print ca_name | sed 's/^.*\s//')
+SET_SERVER=$(puppet config print ca_name | sed 's/^.*\s//')
+CA="${CA:-$SET_SERVER}"
 NODE='mynode.puppetdebug.vlan'
 
 curl -X PUT \

--- a/puppetdb/exported_resources.sh
+++ b/puppetdb/exported_resources.sh
@@ -1,4 +1,8 @@
 # Use the reference form of any resource type you want to query for.
+
+SET_SERVER=$(puppet config print server)
+CONSOLE="${CONSOLE:-$SET_SERVER}"
+
 curl -G -H  "Accept: application/json"            \
-  'http://localhost:8080/pdb/query/v4/resources'  \
+  'http://${CONSOLE}:8080/pdb/query/v4/resources'  \
   --data-urlencode 'query=["=","exported", true]' | jgrep "type=Host"

--- a/puppetdb/get_all_events_for_time_period.sh
+++ b/puppetdb/get_all_events_for_time_period.sh
@@ -2,7 +2,7 @@
 # This script searches PuppetDB's events endpoint for all events between a set
 # time period (24 hours before right now and 24 hours after right now).
 
-PUPPETDB='pe-201620-master.puppetdebug.vlan'
+PUPPETDB=$(puppet config print server)
 
 # Get appropriately formatted timestamps
 # NOTE: this command won't run on BSD `date` because of the -I argument,

--- a/puppetdb/get_all_events_for_time_period.sh
+++ b/puppetdb/get_all_events_for_time_period.sh
@@ -2,7 +2,8 @@
 # This script searches PuppetDB's events endpoint for all events between a set
 # time period (24 hours before right now and 24 hours after right now).
 
-PUPPETDB=$(puppet config print server)
+SET_SERVER=$(puppet config print server)
+PUPPETDB="${PUPPETDB:-$SET_SERVER}"
 
 # Get appropriately formatted timestamps
 # NOTE: this command won't run on BSD `date` because of the -I argument,

--- a/puppetdb/get_authenticated_status.sh
+++ b/puppetdb/get_authenticated_status.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PUPPETDB='puppetdb.puppetlabs.vm'
+PUPPETDB=$(puppet config print server)
 curl -X GET \
   --tlsv1 \
   --cert   $(puppet config print hostcert) \

--- a/puppetdb/get_authenticated_status.sh
+++ b/puppetdb/get_authenticated_status.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-PUPPETDB=$(puppet config print server)
+SET_SERVER=$(puppet config print server)
+PUPPETDB="${PUPPETDB:-$SET_SERVER}"
 curl -X GET \
   --tlsv1 \
   --cert   $(puppet config print hostcert) \

--- a/puppetdb/get_exported_host_resources.sh
+++ b/puppetdb/get_exported_host_resources.sh
@@ -3,7 +3,7 @@
 # have been marked as 'exported' with Puppet (i.e. someone declared an exported
 # host resource like @@host { ... }). I wrote this for our Architect class, but
 # you can modify the query to do whatever you like
-PUPPETDB='puppetdb.puppetlabs.vm'
+PUPPETDB=$(puppet config print server)
 
 curl -X GET \
   --tlsv1 \

--- a/puppetdb/get_exported_host_resources.sh
+++ b/puppetdb/get_exported_host_resources.sh
@@ -3,7 +3,9 @@
 # have been marked as 'exported' with Puppet (i.e. someone declared an exported
 # host resource like @@host { ... }). I wrote this for our Architect class, but
 # you can modify the query to do whatever you like
-PUPPETDB=$(puppet config print server)
+
+SET_SERVER=$(puppet config print server)
+PUPPETDB="${PUPPETDB:-$SET_SERVER}"
 
 curl -X GET \
   --tlsv1 \

--- a/puppetdb/get_facts.sh
+++ b/puppetdb/get_facts.sh
@@ -1,7 +1,10 @@
+SET_SERVER=$(puppet config print server)
+CONSOLE="${CONSOLE:-$SET_SERVER}"
+
 curl -X GET \
   --tlsv1 \
   --data-urlencode query='["and", ["=", "name", "osfamily"], ["=", "value", "RedHat"]]' \
   --cert   $(puppet config print hostcert) \
   --key    $(puppet config print hostprivkey) \
   --cacert $(puppet config print localcacert) \
-  https://$(puppet config print server):8081/pdb/query/v4/facts
+  https://${CONSOLE}:8081/pdb/query/v4/facts

--- a/puppetdb/get_node_record.sh
+++ b/puppetdb/get_node_record.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PUPPETDB='puppetdb.puppetdebug.vlan'
+PUPPETDB=$(puppet config print server)
 NODE='mynode.puppetdebug.vlan'
 
 curl -X GET \

--- a/puppetdb/get_node_record.sh
+++ b/puppetdb/get_node_record.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-PUPPETDB=$(puppet config print server)
+SET_SERVER=$(puppet config print server)
+PUPPETDB="${PUPPETDB:-$SET_SERVER}"
 NODE='mynode.puppetdebug.vlan'
 
 curl -X GET \

--- a/puppetdb/get_old_nodes.sh
+++ b/puppetdb/get_old_nodes.sh
@@ -3,7 +3,7 @@
 # The -I argument doesn't work in OS X -_-
 # Feel free to adjust the days
 CUTOFF_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ" -d '-1 day')
-PUPPETDB='puppetdb.example.com'
+PUPPETDB=$(puppet config print server)
 
 curl -X GET \
   --tlsv1 \

--- a/puppetdb/get_old_nodes.sh
+++ b/puppetdb/get_old_nodes.sh
@@ -3,7 +3,8 @@
 # The -I argument doesn't work in OS X -_-
 # Feel free to adjust the days
 CUTOFF_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ" -d '-1 day')
-PUPPETDB=$(puppet config print server)
+SET_SERVER=$(puppet config print server)
+PUPPETDB="${PUPPETDB:-$SET_SERVER}"
 
 curl -X GET \
   --tlsv1 \

--- a/puppetdb/get_packages_for_node.sh
+++ b/puppetdb/get_packages_for_node.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-PUPPETDB=$(puppet config print server)
+SET_SERVER=$(puppet config print server)
+PUPPETDB="${PUPPETDB:-$SET_SERVER}"
 
 curl -X GET \
   --tlsv1 \

--- a/puppetdb/get_packages_for_node.sh
+++ b/puppetdb/get_packages_for_node.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-PUPPETDB='puppetdb.puppetlabs.vm'
+PUPPETDB=$(puppet config print server)
 
 curl -X GET \
   --tlsv1 \

--- a/puppetserver/clear_jruby_pools.sh
+++ b/puppetserver/clear_jruby_pools.sh
@@ -4,6 +4,9 @@
 #
 # https://docs.puppetlabs.com/puppetserver/latest/admin-api/v1/jruby-pool.html
 
+SET_SERVER=$(hostname -f)
+CONSOLE="${CONSOLE:-$SET_SERVER}"
+
 CONFDIR="$(puppet master --configprint confdir)"
 
 CERT="$(puppet master --confdir "${CONFDIR}" --configprint hostcert)"
@@ -14,4 +17,4 @@ CACERT="$(puppet master --confdir "${CONFDIR}" --configprint localcacert)"
                                 --cert "$CERT" \
                                 --key "$PRIVKEY" \
                                 --cacert "$CACERT" \
-                                "https://$(hostname -f):8140/puppet-admin-api/v1/jruby-pool"
+                                "https://${CONSOLE}:8140/puppet-admin-api/v1/jruby-pool"

--- a/puppetserver/rbac/get_directoryservice.sh
+++ b/puppetserver/rbac/get_directoryservice.sh
@@ -1,4 +1,5 @@
-CONSOLE='console.example.com'
+SET_SERVER=$(puppet config print server)
+CONSOLE="${CONSOLE:-$SET_SERVER}"
 curl -k -X GET https://${CONSOLE}:4433/rbac-api/v1/ds \
   --cert $(puppet config print hostcert) \
   --key $(puppet config print hostprivkey) \

--- a/puppetserver/rbac/set_directoryservice.sh
+++ b/puppetserver/rbac/set_directoryservice.sh
@@ -1,4 +1,5 @@
-CONSOLE='ausplpcon01.us.dell.com'
+SET_SERVER=$(puppet config pring server)
+CONSOLE="${CONSOLE:-$SET_SERVER}"
 curl -k -X PUT https://${CONSOLE}:4433/rbac-api/v1/ds \
   --cert $(puppet config print hostcert) \
   --key $(puppet config print hostprivkey) \

--- a/puppetserver/show_known_environments.sh
+++ b/puppetserver/show_known_environments.sh
@@ -6,7 +6,8 @@ CERT="$(puppet agent --configprint hostcert)"
 CACERT="$(puppet agent --configprint localcacert)"
 PRVKEY="$(puppet agent --configprint hostprivkey)"
 OPTIONS="--cert ${CERT} --cacert ${CACERT} --key ${PRVKEY}"
-MASTER="$(puppet agent --configprint server)"
+SET_SERVER=$(puppet agent --configprint server)
+CONSOLE="${CONSOLE:-$SET_SERVER}"
 
-/opt/puppetlabs/puppet/bin/curl -s -X GET $OPTIONS "https://${MASTER}:8140/puppet/v3/environments" | python -m json.tool
+/opt/puppetlabs/puppet/bin/curl -s -X GET $OPTIONS "https://${CONSOLE}:8140/puppet/v3/environments" | python -m json.tool
 

--- a/puppetserver/status/get_auth_status.sh
+++ b/puppetserver/status/get_auth_status.sh
@@ -1,6 +1,9 @@
+SET_SERVER=$(puppet config print server)
+CONSOLE="${CONSOLE:-$SET_SERVER}"
+
 curl -X GET \
   --tlsv1 \
   --cert   $(puppet config print hostcert) \
   --key    $(puppet config print hostprivkey) \
   --cacert $(puppet config print localcacert) \
-  https://$(puppet config print server):4433/status/v1/services | python -m json.tool
+  https://${CONSOLE}:4433/status/v1/services | python -m json.tool

--- a/puppetserver/status/get_plaintext_status.sh
+++ b/puppetserver/status/get_plaintext_status.sh
@@ -1,4 +1,7 @@
 # puppet_enterprise::profile::console::console_services_plaintext_status_enabled must be set to true
 # in console, PE Console group, puppet_enterprise::profile::console class, console_services_plaintext_status_enabled
 
-curl -X GET http://localhost:8123/status/v1/services
+SET_SERVER=$(puppet config print server)
+CONSOLE="${CONSOLE:-$SET_SERVER}"
+
+curl -X GET http://${CONSOLE}:8123/status/v1/services

--- a/puppetserver/status/get_plaintext_status_debug.sh
+++ b/puppetserver/status/get_plaintext_status_debug.sh
@@ -1,6 +1,9 @@
 # puppet_enterprise::profile::console::console_services_plaintext_status_enabled must be set to true
 # in console, PE Console group, puppet_enterprise::profile::console class, console_services_plaintext_status_enabled
 
+SET_SERVER=$(puppet config print server)
+CONSOLE="${CONSOLE:-$SET_SERVER}"
+
 curl -X GET \
   --data-urlencode 'level=debug' \
-  http://localhost:8123/status/v1/services | python -m json.tool
+  http://${CONSOLE}:8123/status/v1/services | python -m json.tool


### PR DESCRIPTION
In order to make these scripts a little more general, this commit uses
`puppet config print` in order to determine the most likely host for the
API endpoint. Granted, one could still go in and hard-code the desired
value into the script.
