### PR TITLE
remove reference to pe-internal-classifier.pem

### DIFF
--- a/classifier/search_for_a_class.sh
+++ b/classifier/search_for_a_class.sh
@@ -6,8 +6,8 @@ SET_SERVER=$(puppet config print server)
 CONSOLE="${CONSOLE:-$SET_SERVER}"
 
 # Set variables for the curl.
-CERT="/etc/puppetlabs/puppet/ssl/certs/pe-internal-classifier.pem"
-KEY="/etc/puppetlabs/puppet/ssl/private_keys/pe-internal-classifier.pem"
+CERT="/etc/puppetlabs/puppet/ssl/certs/$(puppet config print certname).pem"
+KEY="/etc/puppetlabs/puppet/ssl/private_keys/$(puppet config print certname).pem"
 CACERT="/etc/puppetlabs/puppet/ssl/certs/ca.pem"
 
 /opt/puppetlabs/puppet/bin/curl -s -X GET \


### PR DESCRIPTION
Above cert is now history, just use the certname certificate