### PR TITLE
Corrected typo in puppetserver/rbac/set_directoryservice.sh

### DIFF
--- a/puppetserver/rbac/set_directoryservice.sh
+++ b/puppetserver/rbac/set_directoryservice.sh
@@ -1,4 +1,4 @@
-SET_SERVER=$(puppet config pring server)
+SET_SERVER=$(puppet config print server)
 CONSOLE="${CONSOLE:-$SET_SERVER}"
 curl -k -X PUT https://${CONSOLE}:4433/rbac-api/v1/ds \
   --cert $(puppet config print hostcert) \


### PR DESCRIPTION
puppetserver/rbac/set_directoryservice.sh has a typo in line one that prevents it from running. print is misspelled as pring; this pull request will correct it.