### PR TITLE
Use the latest released version, not 'latest'

### DIFF
--- a/installer/download_pe_tarball.sh
+++ b/installer/download_pe_tarball.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-# This script will download the requested version of PE from S3. It will
-# also resume broken downloads to save time and rename the resultant file
+# This script will download the requested version of PE from S3.
+# If no version is specified, the latest version will be used. It will
+# also resume broken downloads to save time and rename the resultant file.
 
 # INSTALLER CHOICES #
 # Either pass these environment variables inline or modify the default
@@ -9,6 +10,11 @@ DOWNLOAD_DIST=${DOWNLOAD_DIST:-el}
 DOWNLOAD_RELEASE=${DOWNLOAD_RELEASE:-7}
 DOWNLOAD_ARCH=${DOWNLOAD_ARCH:-x86_64}
 DOWNLOAD_VERSION=${DOWNLOAD_VERSION:-latest}
+
+if [[ $DOWNLOAD_VERSION == latest ]]; then
+  latest_released_version_number="$(curl -s http://versions.puppet.com.s3-website-us-west-2.amazonaws.com/ | tail -n1)"
+  DOWNLOAD_VERSION=${latest_released_version_number:-latest}
+fi
 
 tarball_name="puppet-enterprise-${DOWNLOAD_VERSION}-${DOWNLOAD_DIST}-${DOWNLOAD_RELEASE}-${DOWNLOAD_ARCH}.tar.gz"
 


### PR DESCRIPTION
Prior to this, if you ran this script without specifying a version or
you specified 'latest', then the installer would be downloaded with
'latest' in the file name. This made it impossible to tell exactly which
version you just downloaded.

This commit will, if using 'latest', determine exactly which version
number that is and use that rather than the string, 'latest'.

That magic is done by looking at the last line of the page at
"http://versions.puppet.com.s3-website-us-west-2.amazonaws.com"
This isn't neccessarily a "stable" api, but it is what the Puppet
Enterprise download website uses, so hopefully it doesn't change.